### PR TITLE
feat: Allow Nginx ports to be specified in .env file

### DIFF
--- a/setup_pia_docker.sh
+++ b/setup_pia_docker.sh
@@ -78,6 +78,8 @@ RAILS_SERVE_STATIC_FILES=true
 
 # --- PIA Frontend Settings ---
 API_BASE_URL=/api/v1
+# NGINX_HTTP_PORT=80  # Optionnel: Décommentez et modifiez pour changer le port HTTP exposé sur l'hôte
+# NGINX_HTTPS_PORT=443 # Optionnel: Décommentez et modifiez pour changer le port HTTPS exposé sur l'hôte
 
 # --- SSL Certificate Settings ---
 CERT_HOSTNAME=localhost
@@ -164,8 +166,8 @@ services:
     container_name: pia_frontend_web
     restart: unless-stopped
     ports:
-      - "80:80"
-      - "443:443"
+      - "\${NGINX_HTTP_PORT:-80}:80"
+      - "\${NGINX_HTTPS_PORT:-443}:443"
     depends_on:
       - pia-backend
     volumes:
@@ -506,6 +508,7 @@ echo "2. Créez et configurez votre fichier .env :"
 echo "   cp .env.example .env"
 echo "   nano .env  # (Remplissez POSTGRES_PASSWORD et SECRET_KEY_BASE)."
 echo "                # (Optionnel : modifiez CERT_HOSTNAME si vous voulez utiliser un autre nom d'hôte que 'localhost')"
+echo "                # (Optionnel : modifiez NGINX_HTTP_PORT et NGINX_HTTPS_PORT si vous voulez changer les ports Nginx exposés sur la machine hôte)"
 echo "                # (Si vous changez CERT_HOSTNAME pour, par ex., 'pia.local', ajoutez '127.0.0.1 pia.local' à votre fichier /etc/hosts local)"
 echo "3. Construisez les images Docker :"
 echo "   sudo docker-compose build"


### PR DESCRIPTION
This change modifies the `setup_pia_docker.sh` script to enable you to define custom host ports for the Nginx service (pia-frontend) through environment variables in your `.env` file.

Modifications:

1.  **`docker-compose.yml` Generation:** The `pia-frontend` service's port mappings in the generated `docker-compose.yml` file now use `\${NGINX_HTTP_PORT:-80}:80` and `\${NGINX_HTTPS_PORT:-443}:443`. This allows you to override the default host ports (80 and 443) by setting `NGINX_HTTP_PORT` and `NGINX_HTTPS_PORT` in your `.env` file.

2.  **`.env.example` Generation:** The generated `.env.example` file now includes commented-out examples for these new variables: `# NGINX_HTTP_PORT=80` `# NGINX_HTTPS_PORT=443`

3.  **User Instructions:** The "PROCHAINES ÉTAPES" section in the `setup_pia_docker.sh` script has been updated to inform you about these new configurable port variables.